### PR TITLE
Add bower.json for... well, Bower!

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "angucomplete",
+  "version": "1.0.0",
+  "homepage": "http://darylrowland.github.io/angucomplete/",
+  "authors": [
+    "Daryl Rowland <daryl@cloudyclear.com>"
+  ],
+  "description": "Awesome Autocompleteness for AngularJS",
+  "keywords": [
+    "autocomplete",
+    "typeahead",
+    "angularjs"
+  ],
+  "license": "MIT",
+  "main": "./angucomplete.js",
+  "ignore": [
+    "example",
+    "bower_components",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This should be all that is needed to make this available via Bower. Well, this and you can of course register it via `bower register angucomplete https://github.com/darylrowland/angucomplete.git`.

Also, I made this version 1.0.0, as it is used in production, and to give folks some hope of being able to leverage Semantic Versioning. I've also added the `example` directory to the `ignore` list since folks installing via Bower won't want/need those files.
