### PR TITLE
Only search when new term is entered

### DIFF
--- a/angucomplete.js
+++ b/angucomplete.js
@@ -184,7 +184,7 @@ angular.module('angucomplete', [] )
                 if ($scope.matchClass) {
                     result.title = result.title.toString().replace(/(<([^>]+)>)/ig, '');
                 }
-                $scope.searchStr = result.title;
+                $scope.searchStr = $scope.lastSearchTerm = result.title;
                 $scope.selectedObject = result;
                 $scope.showDropdown = false;
                 $scope.results = [];


### PR DESCRIPTION
Not all key presses change the search string (arrow keys to move the cursor, or `CMD + A` to select the text, for example), so we shouldn't queue up a new search unless the actual search term has changed.
