### PR TITLE
Fix: down-arrow and enter key throwing error when input field is empty

### DIFF
--- a/angucomplete.js
+++ b/angucomplete.js
@@ -183,7 +183,7 @@ angular.module('angucomplete', [] )
 
             elem.on("keyup", function (event) {
                 if(event.which === 40) {
-                    if (($scope.currentIndex + 1) < $scope.results.length) {
+                    if ($scope.results && ($scope.currentIndex + 1) < $scope.results.length) {
                         $scope.currentIndex ++;
                         $scope.$apply();
                         event.preventDefault;
@@ -200,7 +200,7 @@ angular.module('angucomplete', [] )
                     }
 
                 } else if (event.which == 13) {
-                    if ($scope.currentIndex >= 0 && $scope.currentIndex < $scope.results.length) {
+                    if ($scope.results && $scope.currentIndex >= 0 && $scope.currentIndex < $scope.results.length) {
                         $scope.selectResult($scope.results[$scope.currentIndex]);
                         $scope.$apply();
                         event.preventDefault;


### PR DESCRIPTION
Pressing down-arrow or enter key throws an error when input field is empty.
