### PR TITLE
Mistaken Bootstrap style override

### DIFF
--- a/angucomplete.css
+++ b/angucomplete.css
@@ -1,16 +1,3 @@
-.form-control {
-    outline: 0;
-    border-color: #ECECEC;
-    border-style: solid;
-    border-width: 1px;
-    width: 95%;
-    background-color: #ffffff;
-    padding: 6px;
-    border-radius: 2px;
-    margin-bottom: 5px;
-    font-size: 14px;
-}
-
 .angucomplete-holder {
     position: relative;
 }


### PR DESCRIPTION
You have mistakenly override Bootstrap style for `.form-control` (not used in autocomplete template).
