### PR TITLE
Do not search for internal object of not defined

### DIFF
--- a/angucomplete.js
+++ b/angucomplete.js
@@ -126,7 +126,7 @@ angular.module('angucomplete', [] )
                         $http.get($scope.url + str, {}).
                             success(function(responseData, status, headers, config) {
                                 $scope.searching = false;
-                                $scope.processResults(responseData[$scope.dataField], str);
+                                $scope.processResults((($scope.dataField) ? responseData[$scope.dataField] : responseData ), str);
                             }).
                             error(function(data, status, headers, config) {
                                 console.log("error");


### PR DESCRIPTION
If settings does not define internal object for results array, don't look inside request - just use one.
