### PR TITLE
Update angucomplete.js

### DIFF
--- a/angucomplete.js
+++ b/angucomplete.js
@@ -111,7 +111,7 @@ angular.module('angucomplete', [] )
                             var match = false;
 
                             for (var s = 0; s < searchFields.length; s++) {
-                                match = match || ($scope.localData[i][searchFields[s]].toLowerCase().indexOf(str.toLowerCase()) >= 0);
+                                match = match || (typeof $scope.localData[i][searchFields[s]] === 'string' && typeof str === 'string' && $scope.localData[i][searchFields[s]].toLowerCase().indexOf(str.toLowerCase()) >= 0);
                             }
 
                             if (match) {


### PR DESCRIPTION
In a large dataset occasionally a parameter could be undefined instead of an empty string.  For example {name: undefined, dob: '02/16/1985'} whereas all the other records contain data.  In this case instead of calling toLowerCase() on the undefined variable and throwing an error - simply check if it is a string first and if not it will move onto the next result.
