### PR TITLE
minLength not updated by @minlength when isNewSearchNeeded 

### DIFF
--- a/angucomplete.js
+++ b/angucomplete.js
@@ -64,7 +64,12 @@ angular.module('angucomplete', [] )
                         var titleCode = [];
 
                         for (var t = 0; t < titleFields.length; t++) {
-                            titleCode.push(responseData[i][titleFields[t]]);
+                            var title_field = titleFields[t].split(".");
+                            var title_data = responseData[i];
+                            title_field.forEach(function(element, index){
+                              title_data = title_data[element];
+                            });
+                            titleCode.push(title_data);
                         }
 
                         var description = "";


### PR DESCRIPTION
251406e - when isNewSearchNeeded is created as a standalone function it always contains the value 3 (at least working with remote data source) because $scope.minLength is not yet been modified by this:

$scope.minLength = $scope.minLengthUser;

putting isNewSearchNeeded inside the $scope solve this problem.

a3365d2 - This allows you to use object.notation in titlefield to get the value of a property, for example if you have the following object structure:

{ one: 1, two: 2, three: { inside: inside_value } }

you can do this: 

titlefield="one,two,three.inside"

the object structure can be as deep as you want: {one: {two: {three: {four: four_value}}}}

titlefield="one.two.three.four"
