### PR TITLE
allow dot syntax for key refrences

### DIFF
--- a/angucomplete.js
+++ b/angucomplete.js
@@ -5,7 +5,7 @@
  */
 
 angular.module('angucomplete', [] )
-    .directive('angucomplete', function ($parse, $http, $sce, $timeout) {
+    .directive('angucomplete', ['$parse', '$http', '$sce', '$timeout', function ($parse, $http, $sce, $timeout) {
 
     return {
         restrict: 'EA',
@@ -271,5 +271,5 @@ angular.module('angucomplete', [] )
 
         }
     };
-});
+}]);
 

--- a/angucomplete.js
+++ b/angucomplete.js
@@ -24,7 +24,8 @@ angular.module('angucomplete', [] )
             "localData": "=localdata",
             "searchFields": "@searchfields",
             "minLengthUser": "@minlength",
-            "matchClass": "@matchclass"
+            "matchClass": "@matchclass",
+            "clearOnSelect": "@clearOnSelect"
         },
         template: '<div class="angucomplete-holder"><input id="{{id}}_value" ng-model="searchStr" type="text" placeholder="{{placeholder}}" class="{{inputClass}}" onmouseup="this.select();" ng-focus="resetHideResults()" ng-blur="hideResults()" /><div id="{{id}}_dropdown" class="angucomplete-dropdown" ng-if="showDropdown"><div class="angucomplete-searching" ng-show="searching">Searching...</div><div class="angucomplete-searching" ng-show="!searching && (!results || results.length == 0)">No results found</div><div class="angucomplete-row" ng-repeat="result in results" ng-click="selectResult(result)" ng-mouseover="hoverRow()" ng-class="{\'angucomplete-selected-row\': $index == currentIndex}"><div ng-if="imageField" class="angucomplete-image-holder"><img ng-if="result.image && result.image != \'\'" ng-src="{{result.image}}" class="angucomplete-image"/><div ng-if="!result.image && result.image != \'\'" class="angucomplete-image-default"></div></div><div class="angucomplete-title" ng-if="matchClass" ng-bind-html="result.title"></div><div class="angucomplete-title" ng-if="!matchClass">{{ result.title }}</div><div ng-if="result.description && result.description != \'\'" class="angucomplete-description">{{result.description}}</div></div></div></div>',
 
@@ -212,7 +213,11 @@ angular.module('angucomplete', [] )
                 if ($scope.matchClass) {
                     result.title = result.title.toString().replace(/(<([^>]+)>)/ig, '');
                 }
-                $scope.searchStr = $scope.lastSearchTerm = result.title;
+                if ($scope.clearOnSelect) {
+                    $scope.searchStr = '';
+                } else {
+                    $scope.searchStr = $scope.lastSearchTerm = result.title;
+                }
                 $scope.selectedObject = result;
                 $scope.showDropdown = false;
                 $scope.results = [];

--- a/angucomplete.js
+++ b/angucomplete.js
@@ -5,7 +5,7 @@
  */
 
 angular.module('angucomplete', [] )
-    .directive('angucomplete', ['$parse', '$http', '$sce', '$timeout', function ($parse, $http, $sce, $timeout) {
+    .directive('angucomplete', ['$parse', '$http', '$q', '$sce', '$timeout', function ($parse, $http, $q, $sce, $timeout) {
 
     return {
         restrict: 'EA',
@@ -52,7 +52,7 @@ angular.module('angucomplete', [] )
                 return newTerm.length >= $scope.minLength && newTerm != oldTerm
             }
 
-            /** 
+            /**
              * given a key string such as "firstName" or "meta.subkey", return the value
              * at the key for object obj.
              * @param {Object} obj: the object context to use
@@ -155,12 +155,12 @@ angular.module('angucomplete', [] )
                         $scope.processResults(matches, str);
 
                     } else {
-                        $http.get($scope.url + str, {}).
-                            success(function(responseData, status, headers, config) {
+                        $q.when($http.get($scope.url + str, {}))
+                            .then(function(responseBody, status, headers, config) {
                                 $scope.searching = false;
-                                $scope.processResults((($scope.dataField) ? getValue(responseData, $scope.dataField) : responseData ), str);
-                            }).
-                            error(function(data, status, headers, config) {
+                                $scope.processResults((($scope.dataField) ? getValue(responseBody.data, $scope.dataField) : responseBody.data ), str);
+                            })
+                            .catch(function(data, status, headers, config) {
                                 console.log("error");
                             });
                     }
@@ -272,4 +272,3 @@ angular.module('angucomplete', [] )
         }
     };
 }]);
-

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "node_modules"
   ],
   "dependencies": {
-    "angular": ">=1.2.0"
+    "angular": ">=1.2.0",
+    "requirejs-plugins": "~1.0.2"
   },
   "devDependencies": {
     "angular-mocks": ">=1.2.0",


### PR DESCRIPTION
I wanted to use a key of a nested object in a response for the `titlefield`. Instead of referencing the key directly with the string, we can split the keys on a `.` and reference the keys that way.
