### PR TITLE
Injecting dependencies using "inline array annotation" instead of "implicit dependencies"

### DIFF
--- a/angucomplete.js
+++ b/angucomplete.js
@@ -12,6 +12,7 @@ angular.module('angucomplete', [] )
             "id": "@id",
             "placeholder": "@placeholder",
             "selectedObject": "=selectedobject",
+            "enteredText": "=enteredtext",
             "url": "@url",
             "dataField": "@datafield",
             "titleField": "@titlefield",
@@ -225,6 +226,8 @@ angular.module('angucomplete', [] )
                         event.stopPropagation();
                     } else {
                         $scope.results = [];
+                        $scope.showDropdown = false;
+                        $scope.enteredText = $scope.searchStr;
                         $scope.$apply();
                         event.preventDefault;
                         event.stopPropagation();


### PR DESCRIPTION
We started getting the Unknown Provider error when I used this library in a Rails app in the production environment, where the JS is minified. I realised this was happening because the dependencies were not injected using inline array annotation. More details here: https://docs.angularjs.org/guide/di#implicit-dependencies. I have now fixed this. 
